### PR TITLE
fix: make IsInRange robust when cursor is on delimiter

### DIFF
--- a/autoload/mde_utils.vim
+++ b/autoload/mde_utils.vim
@@ -411,7 +411,7 @@ export def IsInRange(): dict<list<list<number>>>
 
   # Main function start here
   # text_style comes from vim-markdown
-  const text_style = synIDattr(synID(line("."), col("."), 1), "name")
+  var text_style = synIDattr(synID(line("."), col("."), 1), "name")
 
   # Delimiter smart detection logic (non-recursive, move cursor to content area if found)
   if text_style =~ 'Delimiter'


### PR DESCRIPTION
Repro:
- On a single-line sentence, use `<localleader>bis` to toggle bold.
- First: `This is a |book about dragon. → **This is a book about drag|on.**`
- Second: `**This is a book about drag|on.** → **This is a book about dragon.*|*`
- Bold is not removed if cursor is on the delimiter.

Cause:
- IsInRange() only detected content area, not delimiters, so toggle failed when cursor was on a delimiter.

Solution:
- If cursor is on a delimiter, IsInRange now probes left/right for the content area and moves the cursor there, ensuring surround actions always work.